### PR TITLE
feat: add multilingual support for commit message generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ nlgc
 # Generate using a specific backend and exclude full file content
 nlgc -1 --no-full-files
 
+# Generate commit message in Spanish
+nlgc --language Spanish
+
+# Generate commit message in French using short flag
+nlgc -l French
+
 # Edit the suggested message before committing
 nlgc
 # [Confirm] Use this message? (y/N/e/r) e 
@@ -227,6 +233,11 @@ nlgc:
   # but increases token usage significantly. Can be overridden with
   # --full-files or --no-full-files flags.
   include_full_files: true
+  
+  # Language for commit message generation (e.g., "Spanish", "French", "German")
+  # Set to null or omit for default behavior (English)
+  # Can be overridden with --language/-l flag or NLSH_NLGC_LANGUAGE env var
+  language: null
 ```
 
 *   The `is_reasoning_model` flag is used by `nlsh` to identify models that provide reasoning tokens in their responses. When this flag is set to `true` and verbose mode (`-v`) is enabled, the tool will display the model's reasoning process.
@@ -252,6 +263,7 @@ You can override configuration settings using environment variables:
 *   `NLSH_SHELL`: Overrides the `shell` setting (e.g., `export NLSH_SHELL=fish`).
 *   `NLSH_DEFAULT_BACKEND`: Overrides the `default_backend` index (e.g., `export NLSH_DEFAULT_BACKEND=1`).
 *   `NLSH_NLGC_INCLUDE_FULL_FILES`: Overrides `nlgc.include_full_files` (`true` or `false`).
+*   `NLSH_NLGC_LANGUAGE`: Overrides `nlgc.language` (e.g., `export NLSH_NLGC_LANGUAGE=Spanish`).
 *   `[BACKEND_NAME]_API_KEY`: Sets the API key for a named backend (e.g., `export OPENAI_API_KEY=sk-...`). This takes precedence over `$VAR` references in the config file.
 *   `NLSH_BACKEND_[INDEX]_API_KEY`: Sets the API key for a backend by its index (e.g., `export NLSH_BACKEND_0_API_KEY=sk-...`).
 
@@ -406,6 +418,7 @@ nlsh --prompt-file migration_task.txt
 *   `--full-files`: Forces `nlgc` to include the full content of changed files in the prompt, overriding the `nlgc.include_full_files` config setting.
 *   `--no-full-files`: Forces `nlgc` to exclude the full content of changed files from the prompt, overriding the config setting. Useful if you encounter context length errors.
 *   `-a`, `--all`: Makes `nlgc` consider all tracked, modified files, not just the ones staged for commit.
+*   `--language`, `-l`: Specifies the language for commit message generation (e.g., `--language Spanish`), overriding the `nlgc.language` config setting and `NLSH_NLGC_LANGUAGE` environment variable.
 
 --------
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -31,8 +31,14 @@ default_backend: 0
 
 # Configuration for the 'nlgc' (Neural Git Commit) command
 # Override with environment variable: NLSH_NLGC_INCLUDE_FULL_FILES (true/false)
+# Override with environment variable: NLSH_NLGC_LANGUAGE
 nlgc:
   # Whether to include the full content of changed files in the prompt
   # sent to the LLM for commit message generation. Provides more context
   # but increases token usage significantly.
   include_full_files: true
+  
+  # Language for commit message generation (e.g., "Spanish", "French", "German")
+  # Set to null or omit for default behavior (English)
+  # Can be overridden with --language/-l flag or NLSH_NLGC_LANGUAGE env var
+  language: null

--- a/nlsh/__init__.py
+++ b/nlsh/__init__.py
@@ -5,4 +5,4 @@ This package provides a command-line utility that generates shell commands
 based on natural language input using LLMs.
 """
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/nlsh/config.py
+++ b/nlsh/config.py
@@ -33,7 +33,8 @@ class Config:
         ],
         "default_backend": 0,
         "nlgc": {
-            "include_full_files": True  # Whether nlgc includes full file content by default
+            "include_full_files": True,  # Whether nlgc includes full file content by default
+            "language": None  # Language for commit message generation (e.g., "Spanish", "French")
         }
     }
     
@@ -162,6 +163,10 @@ class Config:
             if "include_full_files" in config["nlgc"]:
                 if not isinstance(config["nlgc"]["include_full_files"], bool):
                     raise ConfigValidationError("nlgc.include_full_files must be a boolean")
+            if "language" in config["nlgc"]:
+                language = config["nlgc"]["language"]
+                if language is not None and (not isinstance(language, str) or not language.strip()):
+                    raise ConfigValidationError("nlgc.language must be null or a non-empty string")
 
     def _load_config_file(self, config_file: str) -> None:
         """Load and validate configuration from file."""
@@ -237,6 +242,11 @@ class Config:
                 self.config.setdefault("nlgc", {})["include_full_files"] = True
             elif env_val in ["false", "0", "no"]:
                 self.config.setdefault("nlgc", {})["include_full_files"] = False
+        
+        if "NLSH_NLGC_LANGUAGE" in os.environ:
+            language = os.environ["NLSH_NLGC_LANGUAGE"].strip()
+            if language:
+                self.config.setdefault("nlgc", {})["language"] = language
 
     def get_shell(self) -> str:
         """Get configured shell.

--- a/nlsh/prompt.py
+++ b/nlsh/prompt.py
@@ -63,6 +63,8 @@ Formatting rules:
 user will provide you a git diff and optionally the full content of changed files, and you have to create a suitable commit message summarizing the changes.
 Output only the commit message (subject and optional body). Do not include explanations or markdown formatting like ```.
 
+{language_instruction}
+
 {declined_messages}
 """
 
@@ -147,11 +149,12 @@ Generate only the command, nothing else."""
             system_context=system_context,
         )
     
-    def build_git_commit_system_prompt(self, declined_messages: List[str] = []) -> str:
+    def build_git_commit_system_prompt(self, declined_messages: List[str] = [], language: str = None) -> str:
         """Build the system prompt for git commit message generation.
         
         Args:
             declined_messages: List of declined commit messages.
+            language: Language for commit message generation.
             
         Returns:
             str: Formatted system prompt for git commit message generation.
@@ -159,8 +162,13 @@ Generate only the command, nothing else."""
         declined_messages_str = ""
         if declined_messages:
             declined_messages_str = "The following commit messages were previously declined by the user, so propose something different:\n\n" + "\n\n----------------\n\n".join(declined_messages)
+        
+        language_instruction = ""
+        if language:
+            language_instruction = f"Generate the commit message in {language}."
             
         return self.GIT_COMMIT_SYSTEM_PROMPT.format(
+            language_instruction=language_instruction,
             declined_messages=declined_messages_str
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neural-shell"
-version = "1.3.1"
+version = "1.3.2"
 description = "Neural Shell (nlsh) - AI-driven command-line assistant"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join("nlsh", "__init__.py"), "r") as f:
             version = line.split("=")[1].strip().strip('"').strip("'")
             break
     else:
-        version = "1.3.1"
+        version = "1.3.2"
 
 # Get long description from README
 with open("README.md", "r") as f:


### PR DESCRIPTION
- Add --language/-l flag to specify output language
- Support language configuration via config file and NLSH_NLGC_LANGUAGE env var
- Update system prompt to include language instruction
- Bump version to 1.3.2
- Update README and example config with new language options